### PR TITLE
[feature/logout] Add logout feature

### DIFF
--- a/__tests__/redux/auth.test.ts
+++ b/__tests__/redux/auth.test.ts
@@ -1,6 +1,12 @@
-import { authReducer, IUserLoginParam, IState, USER_LOGIN } from '@/redux/auth';
+import {
+  authReducer,
+  IUserLoginParam,
+  IState,
+  USER_LOGIN,
+  USER_LOGOUT,
+} from '@/redux/auth';
 
-test('Auth Feature Testing', () => {
+test('Auth Login Feature Testing', () => {
   // given
   const prevState: IState = {
     repoName: '',
@@ -24,6 +30,31 @@ test('Auth Feature Testing', () => {
   // done
   const expectValue = {
     ...userLogin,
+    repoID: '',
+  };
+
+  expect(expectValue).toStrictEqual(resultValue);
+});
+
+test('Auth Logout Feature Testing', () => {
+  // given
+  const prevState: IState = {
+    repoName: 'Dev-Docs',
+    owner: 'BKJang',
+    token: 'testToken',
+    repoID: 'testID',
+  };
+
+  // when
+  const resultValue = authReducer(prevState, {
+    type: USER_LOGOUT,
+  });
+
+  // done
+  const expectValue = {
+    repoName: '',
+    owner: '',
+    token: '',
     repoID: '',
   };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ const config = {
     'ts-jest': {
       diagnostics: true,
     },
+    'window': {}
   },
   testMatch: null,
 };

--- a/src/redux/auth.ts
+++ b/src/redux/auth.ts
@@ -7,7 +7,7 @@ import { ofType, combineEpics, Epic } from 'redux-observable';
 import { ActionInterface } from '@/redux';
 import { getRepoId } from '@/githubApi/repo';
 import { request } from '@/redux/common';
-import { setItem, getItem } from '@/utils/localStorage';
+import { setItem, getItem, deleteItem } from '@/utils/localStorage';
 
 // payload interface
 export interface IState {
@@ -52,7 +52,7 @@ export const userLoginEpic: Epic<ActionInterface> = (
   );
 };
 
-// TODO feature: 로그아웃
+export const userLogout = createAction(USER_LOGOUT);
 
 // initialState
 const CONFIG_KEY = 'config';
@@ -79,6 +79,8 @@ export function authReducer(state = initialState, action: any): IState {
         ...action.payload,
       };
     case USER_LOGOUT:
+      deleteItem(CONFIG_KEY);
+
       return {
         ...initialState,
       };

--- a/src/utils/encrypt.ts
+++ b/src/utils/encrypt.ts
@@ -1,5 +1,11 @@
-export const encode = (value: string): string =>
-  window.btoa(window.encodeURIComponent(value));
+export const encode = (value: string): string => {
+  if (!window.btoa || !window.encodeURIComponent) return '';
 
-export const decode = (encoded: string): string =>
-  window.decodeURIComponent(window.atob(encoded));
+  return window.btoa(window.encodeURIComponent(value));
+};
+
+export const decode = (encoded: string): string => {
+  if (!window.atob || !window.decodeURIComponent) return '';
+
+  return window.decodeURIComponent(window.atob(encoded));
+};

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -5,6 +5,8 @@ export const getItem = (
   defaultValue: any,
   isEncoded: boolean = false,
 ) => {
+  if (!window.localStorage) return defaultValue;
+
   const plainData = window.localStorage.getItem(key);
 
   if (!plainData) return defaultValue;
@@ -23,6 +25,8 @@ export const setItem = (
     ? encode(JSON.stringify(value))
     : JSON.stringify(value);
 
+  if (!window.localStorage) return;
+
   window.localStorage.setItem(key, stringifyData);
 };
 
@@ -30,6 +34,8 @@ export const deleteItem = (key: string): void => {
   if (!key) {
     console.error('key is not defined');
   } else {
-    localStorage.removeItem(key);
+    if (!window.localStorage) return;
+
+    window.localStorage.removeItem(key);
   }
 };


### PR DESCRIPTION
# Description

## Jest setting 추가

- [x] `jest.config.js`에 globals object에 window 객체 추가

```js
// jest.config.js
globals: {
  window: {}
}
```

## Logout 기능 구현

- 파일 경로 : `redux/auth.ts`
- 구현 기능 : userLogout, auth simple testing
 - [x] userLogout
 - [x] auth simple testing
 - [x] LocalStorage에서 삭제하기
 - [x] LocalStorage에 config 내용이 있으면 초기화 셋팅 진행

## localStorage 및 encrypt 내부 window 객체와 관련한 NPE 체크

- 해당 작업을 해주지 않으면 test코드가 돌아갈 때 매번 window 객체에 대한 에러가 발생함.
- NPE 체크 이후 작성한 테스트 코드가 정상적으로 돌아감을 확인했음.
- 혹시나 더 좋은 방법이 있을 것 같아 찾아볼 예정.

### Issue

- [ ] jest의 test function의 types을 읽어오지 못함(@SeonHyungJo)
- [ ] window 객체를 jest 내부에서 돌아가는 방법 찾아보기(현재는 단순히 global setting에 추가함)(@BKJang )