### PR TITLE
[Fearture/Todo-get] 투두 리스트 가져오는 기능 구현 및 테스트 추가

### DIFF
--- a/__tests__/redux/todo.test.ts
+++ b/__tests__/redux/todo.test.ts
@@ -1,80 +1,103 @@
-import { todoReducer, TodoState, TODO_GET_SUCCESS } from '@/redux/todo';
-import { Github_Todo_Edges } from '@/model';
+import { todoReducer, TodoState, successRequestTodo } from '@/redux/todo';
+import { Github_Edges, Github_Issue } from '@/model';
 
-const newIssue: Github_Todo_Edges = [
-  {
-    node: {
-      id: 'MDU6SXNzdWU1NTA3NDM2NTU=',
-      title: 'ㅅㄷㄴㅅ',
-      bodyHTML: '<p>ㅅㄷㄴㅅ</p>',
-      labels: { edges: [] },
-    },
-  },
-  {
-    node: {
-      id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
-      title: 'test2',
-      bodyHTML: '<p>test2</p>',
-      labels: { edges: [] },
-    },
-  },
-  {
-    node: {
-      id: 'MDU6SXNzdWU1NTExMjkzNTQ=',
-      title: 'test',
-      bodyHTML: '',
-      labels: {
-        edges: [
-          {
-            node: {
-              id: 'MDU6TGFiZWwxNzkxMDk1NzIy',
-              name: 'bug',
-              color: 'd73a4a',
-            },
-          },
-          {
-            node: {
-              id: 'MDU6TGFiZWwxNzkxMDk1NzIz',
-              name: 'documentation',
-              color: '0075ca',
-            },
-          },
-          {
-            node: {
-              id: 'MDU6TGFiZWwxNzkxMDk1NzI0',
-              name: 'duplicate',
-              color: 'cfd3d7',
-            },
-          },
-          {
-            node: {
-              id: 'MDU6TGFiZWwxNzkxMDk1NzI1',
-              name: 'enhancement',
-              color: 'a2eeef',
-            },
-          },
-        ],
+const newIssue: Github_Edges<Github_Issue> = {
+  edges: [
+    {
+      node: {
+        id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
+        title: 'test2',
+        bodyHTML: '<p>test2</p>',
+        labels: { edges: [] },
       },
     },
-  },
-];
+    {
+      node: {
+        id: 'MDU6SXNzdWU1NTExMjkzNTQ=',
+        title: 'test',
+        bodyHTML: '',
+        labels: {
+          edges: [
+            {
+              node: {
+                id: 'MDU6TGFiZWwxNzkxMDk1NzIy',
+                name: 'bug',
+                color: 'd73a4a',
+              },
+            },
+            {
+              node: {
+                id: 'MDU6TGFiZWwxNzkxMDk1NzIz',
+                name: 'documentation',
+                color: '0075ca',
+              },
+            },
+            {
+              node: {
+                id: 'MDU6TGFiZWwxNzkxMDk1NzI0',
+                name: 'duplicate',
+                color: 'cfd3d7',
+              },
+            },
+            {
+              node: {
+                id: 'MDU6TGFiZWwxNzkxMDk1NzI1',
+                name: 'enhancement',
+                color: 'a2eeef',
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+};
 
 test('Get Todo Items Testing', () => {
   // given
-  const prevState: TodoState = {
+  const prevState = {
     todoItems: [],
     label: [],
   };
 
   // when
-  const resultValue = todoReducer(prevState, {
-    type: TODO_GET_SUCCESS,
-    payload: newIssue,
-  });
+  const resultValue = todoReducer(prevState, successRequestTodo(newIssue));
 
   // done
   const expectValue: TodoState = {
-    todoItems: [],
+    todoItems: [
+      {
+        title: 'test2',
+        body: '<p>test2</p>',
+        id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
+        modified: false,
+        labelList: [],
+      },
+      {
+        title: 'test',
+        body: '',
+        id: 'MDU6SXNzdWU1NTExMjkzNTQ=',
+        modified: false,
+        labelList: [
+          { id: 'MDU6TGFiZWwxNzkxMDk1NzIy', name: 'bug', color: 'd73a4a' },
+          {
+            id: 'MDU6TGFiZWwxNzkxMDk1NzIz',
+            name: 'documentation',
+            color: '0075ca',
+          },
+          {
+            id: 'MDU6TGFiZWwxNzkxMDk1NzI0',
+            name: 'duplicate',
+            color: 'cfd3d7',
+          },
+          {
+            id: 'MDU6TGFiZWwxNzkxMDk1NzI1',
+            name: 'enhancement',
+            color: 'a2eeef',
+          },
+        ],
+      },
+    ],
     label: [],
   };
 

--- a/__tests__/redux/todo.test.ts
+++ b/__tests__/redux/todo.test.ts
@@ -1,0 +1,82 @@
+import { todoReducer, TodoState, TODO_GET_SUCCESS } from '@/redux/todo';
+import { Github_Todo_Edges } from '@/model';
+
+const newIssue: Github_Todo_Edges = [
+  {
+    node: {
+      id: 'MDU6SXNzdWU1NTA3NDM2NTU=',
+      title: 'ㅅㄷㄴㅅ',
+      bodyHTML: '<p>ㅅㄷㄴㅅ</p>',
+      labels: { edges: [] },
+    },
+  },
+  {
+    node: {
+      id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
+      title: 'test2',
+      bodyHTML: '<p>test2</p>',
+      labels: { edges: [] },
+    },
+  },
+  {
+    node: {
+      id: 'MDU6SXNzdWU1NTExMjkzNTQ=',
+      title: 'test',
+      bodyHTML: '',
+      labels: {
+        edges: [
+          {
+            node: {
+              id: 'MDU6TGFiZWwxNzkxMDk1NzIy',
+              name: 'bug',
+              color: 'd73a4a',
+            },
+          },
+          {
+            node: {
+              id: 'MDU6TGFiZWwxNzkxMDk1NzIz',
+              name: 'documentation',
+              color: '0075ca',
+            },
+          },
+          {
+            node: {
+              id: 'MDU6TGFiZWwxNzkxMDk1NzI0',
+              name: 'duplicate',
+              color: 'cfd3d7',
+            },
+          },
+          {
+            node: {
+              id: 'MDU6TGFiZWwxNzkxMDk1NzI1',
+              name: 'enhancement',
+              color: 'a2eeef',
+            },
+          },
+        ],
+      },
+    },
+  },
+];
+
+test('Get Todo Items Testing', () => {
+  // given
+  const prevState: TodoState = {
+    todoItems: [],
+    label: [],
+  };
+
+  // when
+  const resultValue = todoReducer(prevState, {
+    type: TODO_GET_SUCCESS,
+    payload: newIssue,
+  });
+
+  // done
+  const expectValue: TodoState = {
+    todoItems: [],
+    label: [],
+  };
+
+  expect(expectValue).toStrictEqual(resultValue);
+});

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -22,12 +22,12 @@ class App {
         dispatch: store.dispatch,
       });
       this.currentPath = PATH_CONFIG;
-      // } else {
-      //   this.$main = new Main($target, {
-      //     data: this.rootStore.todo,
-      //     dispatch: store.dispatch,
-      //   });
-      //   this.currentPath = PATH_INDEX;
+    } else {
+      this.$main = new Main($target, {
+        data: this.rootStore.todo,
+        dispatch: store.dispatch,
+      });
+      this.currentPath = PATH_INDEX;
     }
   }
 }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -25,3 +25,21 @@ export interface Config {
   repoName: string;
   repoId: REPOSITORY_ID;
 }
+
+export type GET_CONFIG = Omit<Config, 'token' | 'repoId'>;
+
+// ===== GITHUB MODEL =====
+export interface Github_Edges<T> {
+  edges: Array<Github_Node<T>>;
+}
+
+export interface Github_Node<T> {
+  node: T;
+}
+
+export interface Github_Issue {
+  id: string;
+  title: string;
+  bodyHTML: string;
+  labels: Github_Edges<Label>;
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -7,7 +7,7 @@ export type TODO_ID = string;
 
 export interface Label {
   id: LABEL_ID;
-  title: string;
+  name: string;
   color: string;
 }
 

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -3,7 +3,7 @@ import { createEpicMiddleware, combineEpics } from 'redux-observable';
 import logger from 'redux-logger';
 
 import { authReducer, authEpic } from './auth';
-import { todoReducer } from './todo';
+import { todoReducer, todoEpic } from './todo';
 
 export interface ActionInterface {
   type: string;
@@ -15,7 +15,7 @@ const rootReudcer = combineReducers({
   todo: todoReducer,
 });
 
-const rootEpic = combineEpics(authEpic);
+const rootEpic = combineEpics(authEpic, todoEpic);
 const epicMiddleware = createEpicMiddleware<ActionInterface>();
 
 export default function configureStore() {

--- a/src/redux/todo.ts
+++ b/src/redux/todo.ts
@@ -16,6 +16,7 @@ import {
 import { ActionInterface } from '@/redux';
 import { request } from './common';
 import { getIssueQuery } from '@/githubApi/issue';
+import { setItem } from '@/utils/localStorage';
 
 // payload interface
 export interface TodoState {
@@ -97,6 +98,8 @@ const getTodoEpic: Epic<ActionInterface> = (
 // TODO feature: 투두 추가|수정|Close|삭제 이후 서버의 데이터와 일치하는지 확인하는 기능
 
 // initialState
+const TODO_KEY = 'todo';
+const LABEL_KEY = 'label';
 const initialState: TodoState = {
   todoItems: [],
   label: [],
@@ -109,6 +112,8 @@ export const todoReducer = handleActions(
       state: TodoState,
       { payload }: Action<TODO_LIST>,
     ): TodoState => {
+      setItem(TODO_KEY, payload, false);
+
       return {
         ...state,
         todoItems: payload,

--- a/src/redux/todo.ts
+++ b/src/redux/todo.ts
@@ -1,23 +1,42 @@
+import { Observable } from 'rxjs';
 import { createAction, handleActions } from 'redux-actions';
-import { TODO_LIST, LABEL_LIST } from '@/model';
+import { Epic, ofType, combineEpics, StateObservable } from 'redux-observable';
+import { mergeMap, map } from 'rxjs/operators';
+import { AjaxResponse } from 'rxjs/ajax';
+
+import {
+  TODO_LIST,
+  LABEL_LIST,
+  Todo,
+  Label,
+  Github_Issue,
+  Github_Node,
+} from '@/model';
+import { ActionInterface } from '@/redux';
+import { request } from './common';
+import { getIssueQuery } from '@/githubApi/issue';
 
 // payload interface
 export interface TodoState {
-  todo: TODO_LIST;
+  todoItems: TODO_LIST;
   label: LABEL_LIST;
 }
 
 // type
-const TODO_GET = 'todo/GET';
-const TODO_ADD = 'todo/ADD';
-const TODO_DONE = 'todo/DONE';
-const TODO_UPDATE = 'todo/UPDATE';
-const TODO_DELETE = 'todo/DELETE';
+export const TODO_GET = 'todo/GET';
+export const TODO_GET_SUCCESS = 'todo/GET/SUCCESS';
+export const TODO_GET_FAIL = 'todo/GET/FAIL';
 
-const LABEL_GET = 'label/GET';
+export const TODO_ADD = 'todo/ADD';
+export const TODO_DONE = 'todo/DONE';
+export const TODO_UPDATE = 'todo/UPDATE';
+export const TODO_DELETE = 'todo/DELETE';
+
+export const LABEL_GET = 'label/GET';
 
 // action
 export const getTodo = createAction(TODO_GET);
+
 export const addTodo = createAction(TODO_ADD);
 export const doneTodo = createAction(TODO_DONE);
 export const updateTodo = createAction(TODO_UPDATE);
@@ -26,7 +45,22 @@ export const delTodo = createAction(TODO_DELETE);
 export const getLabel = createAction(LABEL_GET);
 
 // epic
-// TODO feature: 투두 리스트 가져오기
+const getTodoEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(TODO_GET),
+    mergeMap(() => {
+      return request(getIssueQuery(state$.value.auth)).pipe(
+        map(({ response: { data } }: AjaxResponse) => ({
+          type: TODO_GET_SUCCESS,
+          payload: data.repository.issues.edges,
+        })),
+      );
+    }),
+  );
+};
 
 // TODO feature: 투두 추가
 
@@ -40,36 +74,61 @@ export const getLabel = createAction(LABEL_GET);
 
 // initialState
 const initialState: TodoState = {
-  todo: [],
+  todoItems: [],
   label: [],
 };
 
 //reducer
 export const todoReducer = handleActions(
   {
+    [TODO_GET_SUCCESS]: (state: TodoState, action: any): TodoState => {
+      const newTodoList: Array<Todo> = action.payload.map(
+        ({ node }: Github_Node<Github_Issue>) => {
+          const labelList =
+            node?.labels?.edges?.map(
+              ({ node }: Github_Node<Label>): Label => ({ ...node }),
+            ) ?? [];
+
+          return {
+            title: node.title,
+            body: node.bodyHTML,
+            id: node.id,
+            modified: false,
+            labelList,
+          };
+        },
+      );
+
+      return {
+        ...state,
+        todoItems: newTodoList,
+      };
+    },
     [TODO_ADD]: (state: TodoState, action: any): TodoState => {
       return {
         ...state,
-        todo: [...state.todo, action.payload],
+        todoItems: [...state.todoItems, action.payload],
       };
     },
     [TODO_UPDATE]: (state: TodoState, { payload }: any): TodoState => {
       const targetId = payload.id;
-      const newTodo = state.todo.map(item =>
+      const newTodo = state.todoItems.map(item =>
         item.id === targetId ? payload : item,
       );
       return {
         ...state,
-        todo: [...newTodo],
+        todoItems: [...newTodo],
       };
     },
     [TODO_DELETE]: (state: TodoState, { payload: { id } }: any): TodoState => {
-      const newTodo = state.todo.filter(item => item.id !== id);
+      const newTodo = state.todoItems.filter(item => item.id !== id);
       return {
         ...state,
-        todo: [...newTodo],
+        todoItems: [...newTodo],
       };
     },
   },
   initialState,
 );
+
+export const todoEpic = combineEpics(getTodoEpic);


### PR DESCRIPTION
# Description

## Get Todo 기능 구현

- 파일 경로 : `redux/todo.ts`
- 구현 기능 : userLogin, userLoginAsync, auth simple testing
  - [x] Github에서 가져오는 데이터의 형식을 맞춰주기 위해서 모델링 진행 
  - [x] 로그인 기능과 동일하게 서버로 요청 및 Redux의 담아주는 기능 수행
  - [x] LocalStorage에 담기
  - [x] Github에서 넘어오는 데이터 모델링 진행(@/model) 

현재 Epic과 Redux Action이 섞여서 작동하고 있는데, 해당 설계는 Reducer에서는 Redux에 대한 CRUD와 Localstorage 관련 처리 로직이 들어갔으며, 동기적인 처리이면서 Reducer에 담기전 비즈니스 로직은 Action, 이외의 비동기적 처리는 Epic으로 처리되어있습니다.

참고 바랍니다. 

## Issue

