### PR TITLE
[Fearture/get-label] 라벨 리스트 가져오는 기능 구현 및 테스트 코드 추가

### DIFF
--- a/__tests__/redux/label.test.ts
+++ b/__tests__/redux/label.test.ts
@@ -1,0 +1,44 @@
+import { todoReducer, TodoState, LABEL_SET } from '@/redux/todo';
+import { LABEL_LIST } from '@/model';
+
+const newLabels: LABEL_LIST = [
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzIy', name: 'bug', color: 'd73a4a' },
+  {
+    id: 'MDU6TGFiZWwxNzkxMDk1NzIz',
+    name: 'documentation',
+    color: '0075ca',
+  },
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzI0', name: 'duplicate', color: 'cfd3d7' },
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzI1', name: 'enhancement', color: 'a2eeef' },
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzI2', name: 'help wanted', color: '008672' },
+  {
+    id: 'MDU6TGFiZWwxNzkxMDk1NzI3',
+    name: 'good first issue',
+    color: '7057ff',
+  },
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzI4', name: 'invalid', color: 'e4e669' },
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzI5', name: 'question', color: 'd876e3' },
+  { id: 'MDU6TGFiZWwxNzkxMDk1NzMw', name: 'wontfix', color: 'ffffff' },
+];
+
+test('Get Labels Testing', () => {
+  // given
+  const prevState = {
+    todoItems: [],
+    label: [],
+  };
+
+  // when
+  const resultValue = todoReducer(prevState, {
+    type: LABEL_SET,
+    payload: newLabels,
+  });
+
+  // done
+  const expectValue: TodoState = {
+    todoItems: [],
+    label: newLabels,
+  };
+
+  expect(expectValue).toStrictEqual(resultValue);
+});

--- a/src/githubApi/label/index.ts
+++ b/src/githubApi/label/index.ts
@@ -3,7 +3,6 @@ import { Config } from '@/model';
 export const getLabelQuery = ({ repoName, owner }: Config): string => `
   query {
     repository(name: "${repoName}", owner: "${owner}") {
-      id
       labels(first: 100) {
         edges {
           node {

--- a/src/redux/todo.ts
+++ b/src/redux/todo.ts
@@ -17,6 +17,7 @@ import { ActionInterface } from '@/redux';
 import { request } from './common';
 import { getIssueQuery } from '@/githubApi/issue';
 import { setItem } from '@/utils/localStorage';
+import { getLabelQuery } from '@/githubApi/label';
 
 // payload interface
 export interface TodoState {
@@ -34,6 +35,7 @@ export const TODO_UPDATE = 'todo/UPDATE';
 export const TODO_DELETE = 'todo/DELETE';
 
 export const LABEL_GET = 'label/GET';
+export const LABEL_SET = 'label/SET';
 
 export const TODO_FAIL = 'todo/GET/FAIL';
 
@@ -97,6 +99,33 @@ const getTodoEpic: Epic<ActionInterface> = (
 
 // TODO feature: 투두 추가|수정|Close|삭제 이후 서버의 데이터와 일치하는지 확인하는 기능
 
+const getLabelEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(LABEL_GET),
+    mergeMap(() =>
+      request(getLabelQuery(state$.value.auth)).pipe(
+        map(({ response: { data } }: AjaxResponse) => {
+          const labelList: LABEL_LIST = data.repository.labels.edges.map(
+            ({ node }: Github_Node<Label>) => ({
+              id: node.id,
+              name: node.name,
+              color: node.color,
+            }),
+          );
+
+          return {
+            type: LABEL_SET,
+            payload: labelList,
+          };
+        }),
+      ),
+    ),
+  );
+};
+
 // initialState
 const TODO_KEY = 'todo';
 const LABEL_KEY = 'label';
@@ -106,7 +135,7 @@ const initialState: TodoState = {
 };
 
 //reducer
-export const todoReducer = handleActions(
+export const todoReducer = handleActions<TodoState, any>(
   {
     [TODO_SET]: (
       state: TodoState,
@@ -142,8 +171,19 @@ export const todoReducer = handleActions(
         todoItems: [...newTodo],
       };
     },
+    [LABEL_SET]: (
+      state: TodoState,
+      { payload }: Action<LABEL_LIST>,
+    ): TodoState => {
+      setItem(LABEL_KEY, payload, false);
+
+      return {
+        ...state,
+        label: payload,
+      };
+    },
   },
   initialState,
 );
 
-export const todoEpic = combineEpics(getTodoEpic);
+export const todoEpic = combineEpics(getTodoEpic, getLabelEpic);


### PR DESCRIPTION
# Description

## Label 리스트 가져오기 기능 구현

- 파일 경로 : `redux/todo.ts`
- 구현 기능 : getLabelEpic
  - [x] Epic단에서 호출 후 LABEL_SET Action을 통해서 정제된 데이터 전송
  - [x] 논의대로 Success 부분을 제거하고 합치도록 처리
  - [x] LocalStorage에 담기
  - [x] 테스트 코드 작성 

## Issue