### PR TITLE
[feature/update-todo] Upadte Todo 구현중

### DIFF
--- a/__tests__/redux/todo.test.ts
+++ b/__tests__/redux/todo.test.ts
@@ -1,9 +1,4 @@
-import {
-  todoReducer,
-  ITodoState,
-  successRequestTodo,
-  addTodo,
-} from '@/redux/todo';
+import { todoReducer, ITodoState, successRequestTodo } from '@/redux/todo';
 import { Github_Edges, Github_Issue, Todo } from '@/model';
 
 const newIssue: Github_Edges<Github_Issue> = {
@@ -131,6 +126,52 @@ test('Add Todo Items Testing', () => {
 
   const expectValue: ITodoState = {
     todoItems: [addTodoParams],
+    label: [],
+  };
+
+  expect(expectValue).toStrictEqual(resultValue);
+});
+
+test('Update Todo Items Testing', () => {
+  // given
+  const prevState = {
+    todoItems: [
+      {
+        title: 'test2',
+        body: '<p>test2</p>',
+        id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
+        modified: false,
+        labelList: [],
+      },
+    ],
+    label: [],
+  };
+
+  const updateTodoState: Todo = {
+    id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
+    title: 'test3',
+    body: '<p>test2</p>',
+    labelList: [],
+  };
+
+  // when
+  const resultValue = todoReducer(prevState, {
+    type: 'todo/UPDATE',
+    payload: {
+      ...updateTodoState,
+    },
+  });
+
+  const expectValue: ITodoState = {
+    todoItems: [
+      {
+        id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
+        title: 'test3',
+        body: '<p>test2</p>',
+        modified: false,
+        labelList: [],
+      },
+    ],
     label: [],
   };
 

--- a/src/githubApi/issue/index.ts
+++ b/src/githubApi/issue/index.ts
@@ -51,12 +51,21 @@ export const getIssueQuery = ({ owner, repoName }: Config): string => `
 
 export const updateIssueQuery = ({ id, title, body }: Todo): string => `
   mutation {
-    updateIssue(input: {id: "${id}", body: "${body}", title: "${title}}) {
+    updateIssue(input: {id: "${id}", body: "${body}", title: "${title}"}) {
       issue {
         updatedAt
         title
         id
         bodyHTML
+        labels(first: 10) {
+          edges {
+            node {
+              id
+              name
+              color
+            }
+          }
+        }
       }
     }
   }

--- a/src/githubApi/issue/index.ts
+++ b/src/githubApi/issue/index.ts
@@ -49,12 +49,9 @@ export const getIssueQuery = ({ owner, repoName }: Config): string => `
   }
 `;
 
-export const updateIssueQuery = (
-  repoId: REPOSITORY_ID,
-  { title, body }: Todo,
-): string => `
+export const updateIssueQuery = ({ id, title, body }: Todo): string => `
   mutation {
-    updateIssue(input: {id: "${repoId}", body: "${body}", title: "${title}}) {
+    updateIssue(input: {id: "${id}", body: "${body}", title: "${title}}) {
       issue {
         updatedAt
         title

--- a/src/redux/todo.ts
+++ b/src/redux/todo.ts
@@ -261,7 +261,7 @@ export const todoReducer = handleActions<ITodoState, any>(
     ): ITodoState => {
       const targetId = payload.id;
       const updatedTodoList = state.todoItems.map(item =>
-        item.id === targetId ? payload : item,
+        item.id === targetId ? { ...payload, modified: false } : item,
       );
       setItem(TODO_KEY, updatedTodoList, false);
 


### PR DESCRIPTION
# Description

## Add Todo 기능 구현

- 파일 경로 : `redux/todo.ts`
- 구현 기능 : updateTodo,  updateTodoEpic, update todo test code
 - [x] updateTodo
 - [x] updateTodoEpic
 - [x] updateTodo test code

### Issue

- [x] 기존에 구현된 `updateIssueQuery`에서 버그가 있는 것 같음 정상적으로 요청은 넘어가지만 response error가 발생함. 확인 필요!
- [x] `updateIssueQuery`의 파라미터로 labelList가 현재 안넘어가고 있는데 넘어가도록 수정해야하는거 아닌지, 그리고 형식은 어떻게 보낼 건지 확인 필요.

**위 이슈만 해결되면 구현은 크게 어려움 없어보이니 이어서 작업할거면 merge 처리하고 merge 처리하지말고 다른 기능 구현 진행하면 될 듯 함**