### PR TITLE
[feature/epic arrangement] Epic 설계 변경 및 구조 변경

### DIFF
--- a/__tests__/redux/todo.test.ts
+++ b/__tests__/redux/todo.test.ts
@@ -70,14 +70,14 @@ test('Get Todo Items Testing', () => {
         title: 'test2',
         body: '<p>test2</p>',
         id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
-        modified: false,
+        status: 'normal',
         labelList: [],
       },
       {
         title: 'test',
         body: '',
         id: 'MDU6SXNzdWU1NTExMjkzNTQ=',
-        modified: false,
+        status: 'normal',
         labelList: [
           { id: 'MDU6TGFiZWwxNzkxMDk1NzIy', name: 'bug', color: 'd73a4a' },
           {
@@ -140,7 +140,7 @@ test('Update Todo Items Testing', () => {
         title: 'test2',
         body: '<p>test2</p>',
         id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
-        modified: false,
+        status: 'normal',
         labelList: [],
       },
     ],
@@ -168,7 +168,7 @@ test('Update Todo Items Testing', () => {
         id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
         title: 'test3',
         body: '<p>test2</p>',
-        modified: false,
+        status: 'normal',
         labelList: [],
       },
     ],
@@ -186,14 +186,14 @@ test('Delete Todo Items Testing', () => {
         title: 'test2',
         body: '<p>test2</p>',
         id: 'MDU6SXNzdWU1NTA3NDM3NDQ=',
-        modified: false,
+        status: 'normal',
         labelList: [],
       },
       {
         title: 'test',
         body: '',
         id: 'MDU6SXNzdWU1NTExMjkzNTQ=',
-        modified: false,
+        status: 'normal',
         labelList: [
           { id: 'MDU6TGFiZWwxNzkxMDk1NzIy', name: 'bug', color: 'd73a4a' },
           {

--- a/src/components/Config.ts
+++ b/src/components/Config.ts
@@ -1,5 +1,3 @@
-import { userLogin } from '@/redux/auth';
-
 class Config {
   $configPage: HTMLElement;
   data: any; // Todo 정의 필요

--- a/src/components/TodoItem.ts
+++ b/src/components/TodoItem.ts
@@ -1,4 +1,4 @@
-import LabelItem from './LabelItem';
+import LabelItem from '@/components/LabelItem';
 
 class TodoItem {
   $todoItem: HTMLElement;

--- a/src/githubApi/issue/index.ts
+++ b/src/githubApi/issue/index.ts
@@ -17,7 +17,19 @@ export const createIssueQuery = (
       labelIds: ${JSON.stringify(labelIds)}
     }) {
       issue {
+        updatedAt
         id
+        title
+        bodyHTML
+        labels(first: 10) {
+          edges {
+            node {
+              id
+              name
+              color
+            }
+          }
+        }
       }
     }
   }

--- a/src/githubApi/issue/index.ts
+++ b/src/githubApi/issue/index.ts
@@ -2,9 +2,9 @@ import { REPOSITORY_ID, TODO_ID, Config, Todo } from '@/model';
 
 export const createIssueQuery = (
   repositoryId: REPOSITORY_ID,
-  { title, body, labelList = [] }: Todo,
+  { title, body, labels = [] }: Todo,
 ): string => {
-  const labelIds = labelList.map(item => {
+  const labelIds = labels.map(item => {
     return item.id;
   });
 
@@ -42,6 +42,7 @@ export const getIssueQuery = ({ owner, repoName }: Config): string => `
       issues(first: 20, states: OPEN) {
         edges {
           node {
+            updatedAt
             id
             title
             bodyHTML

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -15,7 +15,7 @@ export interface Todo {
   title: string;
   body: string;
   id?: TODO_ID;
-  modified?: boolean;
+  status?: string; // created, updated, deleted, normal
   labelList?: LABEL_LIST;
 }
 

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -12,11 +12,12 @@ export interface Label {
 }
 
 export interface Todo {
+  updatedAt?: string; // ISO-8601 encoded UTC date string.
+  id?: TODO_ID;
   title: string;
   body: string;
-  id?: TODO_ID;
   status?: string; // created, updated, deleted, normal
-  labelList?: LABEL_LIST;
+  labels?: LABEL_LIST;
 }
 
 export interface Config {
@@ -38,6 +39,7 @@ export interface Github_Node<T> {
 }
 
 export interface Github_Issue {
+  updatedAt: string;
   id: string;
   title: string;
   bodyHTML: string;

--- a/src/redux/epics/index.ts
+++ b/src/redux/epics/index.ts
@@ -1,0 +1,5 @@
+import { combineEpics } from 'redux-observable';
+import * as LABEL_EPICS from '@/redux/epics/labelEpic';
+import * as TODO_EPICS from '@/redux/epics/todoEpic';
+
+export default combineEpics({ LABEL_EPICS, TODO_EPICS });

--- a/src/redux/epics/index.ts
+++ b/src/redux/epics/index.ts
@@ -1,5 +1,5 @@
 import { combineEpics } from 'redux-observable';
-import * as LABEL_EPICS from '@/redux/epics/labelEpic';
-import * as TODO_EPICS from '@/redux/epics/todoEpic';
+import TODO_EPICS from '@/redux/epics/todoEpic';
+import LABEL_EPICS from '@/redux/epics/labelEpic';
 
-export default combineEpics({ LABEL_EPICS, TODO_EPICS });
+export default combineEpics(TODO_EPICS, LABEL_EPICS);

--- a/src/redux/epics/labelEpic.ts
+++ b/src/redux/epics/labelEpic.ts
@@ -1,0 +1,37 @@
+import { Observable } from 'rxjs';
+import { Epic, ofType, StateObservable } from 'redux-observable';
+import { mergeMap, map } from 'rxjs/operators';
+import { AjaxResponse } from 'rxjs/ajax';
+
+import { ActionInterface } from '@/redux';
+import { request } from '@/redux/common';
+import { LABEL_LIST, Label, Github_Node } from '@/model';
+import { getLabelQuery } from '@/githubApi/label';
+import { LABEL_GET, LABEL_SET } from '@/redux/todo';
+
+export const getLabelEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(LABEL_GET),
+    mergeMap(() =>
+      request(getLabelQuery(state$.value.auth)).pipe(
+        map(({ response: { data } }: AjaxResponse) => {
+          const labelList: LABEL_LIST = data.repository.labels.edges.map(
+            ({ node }: Github_Node<Label>) => ({
+              id: node.id,
+              name: node.name,
+              color: node.color,
+            }),
+          );
+
+          return {
+            type: LABEL_SET,
+            payload: labelList,
+          };
+        }),
+      ),
+    ),
+  );
+};

--- a/src/redux/epics/labelEpic.ts
+++ b/src/redux/epics/labelEpic.ts
@@ -5,11 +5,11 @@ import { AjaxResponse } from 'rxjs/ajax';
 
 import { ActionInterface } from '@/redux';
 import { request } from '@/redux/common';
+import { LABEL_GET, LABEL_SET } from '@/redux/todo';
 import { LABEL_LIST, Label, Github_Node } from '@/model';
 import { getLabelQuery } from '@/githubApi/label';
-import { LABEL_GET, LABEL_SET } from '@/redux/todo';
 
-export const getLabelEpic: Epic<ActionInterface> = (
+const getLabelEpic: Epic<ActionInterface> = (
   action$: Observable<ActionInterface>,
   state$: StateObservable<any>,
 ) => {
@@ -35,3 +35,5 @@ export const getLabelEpic: Epic<ActionInterface> = (
     ),
   );
 };
+
+export default getLabelEpic;

--- a/src/redux/epics/todoEpic.ts
+++ b/src/redux/epics/todoEpic.ts
@@ -1,0 +1,155 @@
+import { Observable, of } from 'rxjs';
+import { Epic, ofType, StateObservable } from 'redux-observable';
+import { mergeMap, map, catchError, delay } from 'rxjs/operators';
+import { AjaxResponse } from 'rxjs/ajax';
+
+import { ActionInterface } from '@/redux';
+import { request } from '@/redux/common';
+import { getLabels } from '@/utils/common';
+import { TODO_ID } from '@/model';
+import {
+  getIssueQuery,
+  createIssueQuery,
+  updateIssueQuery,
+  deleteIssueQuery,
+} from '@/githubApi/issue';
+import {
+  TODO_ADD_BATCH,
+  TODO_ITEM_SET,
+  BATCH,
+  TODO_GET,
+  TODO_UPDATE,
+  TODO_DELETE,
+  TODO_DELETE_ASYNC,
+  successRequestTodo,
+  TODO_ADD,
+  TODO_UPDATE_ASYNC,
+} from '@/redux/todo';
+
+const fetchCreateFulfilled = (
+  targetId: TODO_ID,
+  {
+    response: {
+      data: {
+        createIssue: { issue },
+      },
+    },
+  }: AjaxResponse,
+) => {
+  return {
+    type: TODO_ITEM_SET,
+    payload: {
+      targetId,
+      todoItem: {
+        updatedAt: issue.updatedAt,
+        id: issue.id,
+        title: issue.title,
+        body: issue.bodyHTML,
+        labelList: getLabels(issue.labels),
+      },
+    },
+  };
+};
+
+const catchErrorToBatch = (type: string, payload: any) => {
+  return {
+    type: BATCH,
+    payload: {
+      type,
+      payload,
+    },
+    error: true,
+  };
+};
+
+export const getTodoEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(TODO_GET),
+    mergeMap(() => {
+      return request(getIssueQuery(state$.value.auth)).pipe(
+        map(({ response: { data } }: AjaxResponse) =>
+          successRequestTodo(data.repository.issues),
+        ),
+      );
+    }),
+  );
+};
+
+export const addTodoEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(TODO_ADD, TODO_ADD_BATCH),
+    mergeMap(({ payload }: ActionInterface) => {
+      const respositoryID = state$.value?.auth.repoID;
+
+      return request(createIssueQuery(respositoryID, payload)).pipe(
+        map((response: AjaxResponse) =>
+          fetchCreateFulfilled(payload.id, response),
+        ),
+        catchError(() => of(catchErrorToBatch(TODO_ADD, payload))),
+      );
+    }),
+  );
+};
+
+export const updateTodoEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(TODO_UPDATE_ASYNC),
+    mergeMap((action: ActionInterface) =>
+      request(updateIssueQuery(action.payload)).pipe(
+        map(({ response: { data } }: AjaxResponse) => ({
+          type: TODO_UPDATE,
+          payload: {
+            ...data.updateIssue.issue,
+          },
+        })),
+      ),
+    ),
+  );
+};
+
+export const deleteTodoEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+  state$: StateObservable<any>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(TODO_DELETE_ASYNC),
+    mergeMap((action: ActionInterface) => {
+      const issueID = action.payload && action.payload.id;
+      return request(deleteIssueQuery(issueID)).pipe(
+        map(({ response: { data } }: AjaxResponse) => ({
+          type: TODO_DELETE,
+          payload: {
+            ...action.payload,
+            id: data.closeIssue.issue.id,
+          },
+        })),
+      );
+    }),
+  );
+};
+
+// TODO feature: 투두 추가|수정|삭제 이후 서버의 데이터와 일치하는지 확인하는 기능
+
+export const batchEpic: Epic<ActionInterface> = (
+  action$: Observable<ActionInterface>,
+) => {
+  return action$.pipe(
+    ofType<ActionInterface>(BATCH),
+    delay(4000),
+    map(({ payload }: ActionInterface) => {
+      return {
+        ...payload,
+        type: payload.type + '/BATCH',
+      };
+    }),
+  );
+};

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -2,8 +2,9 @@ import { applyMiddleware, createStore, combineReducers } from 'redux';
 import { createEpicMiddleware, combineEpics } from 'redux-observable';
 import logger from 'redux-logger';
 
-import { authReducer, authEpic } from './auth';
-import { todoReducer, todoEpic } from './todo';
+import { authReducer, authEpic } from '@/redux/auth';
+import { todoReducer } from '@/redux/todo';
+import * as EPICS from '@/redux/epics';
 
 export interface ActionInterface {
   type: string;
@@ -15,7 +16,7 @@ const rootReudcer = combineReducers({
   todo: todoReducer,
 });
 
-const rootEpic = combineEpics(authEpic, todoEpic);
+const rootEpic = combineEpics(authEpic, EPICS);
 const epicMiddleware = createEpicMiddleware<ActionInterface>();
 
 export default function configureStore() {

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -4,7 +4,7 @@ import logger from 'redux-logger';
 
 import { authReducer, authEpic } from '@/redux/auth';
 import { todoReducer } from '@/redux/todo';
-import * as EPICS from '@/redux/epics';
+import EPICS from '@/redux/epics';
 
 export interface ActionInterface {
   type: string;

--- a/src/redux/todo.ts
+++ b/src/redux/todo.ts
@@ -1,17 +1,8 @@
 import { createAction, handleActions, Action } from 'redux-actions';
 
+import { TODO_LIST, LABEL_LIST, Todo, TODO_ID } from '@/model';
 import { setItem, getItem } from '@/utils/localStorage';
 import { createUniqueId } from '@/utils/common';
-import {
-  TODO_LIST,
-  LABEL_LIST,
-  Todo,
-  Label,
-  Github_Issue,
-  Github_Node,
-  Github_Edges,
-  TODO_ID,
-} from '@/model';
 
 // payload interface
 export interface ITodoState {
@@ -19,83 +10,78 @@ export interface ITodoState {
   label: LABEL_LIST;
 }
 
-const STATUS_CREATE = 'created';
-const STATUS_MODIFY = 'modify';
-const STATUS_DELETE = 'delete';
-const STATUS_NORMAL = 'normal';
+export const STATUS_CREATE = 'created';
+export const STATUS_UPDATE = 'updated';
+export const STATUS_DELETE = 'deleted';
+export const STATUS_NORMAL = 'normal';
 
 // type
 export const BATCH = 'todo/BATCH';
 
-export const TODO_GET = 'todo/GET';
-export const TODO_SET = 'todo/GET/SUCCESS';
+export const TODO_SET = 'todo/SET';
 export const TODO_ITEM_SET = 'todo/ITEM/SET';
+
+export const TODO_GET = 'todo/GET';
+export const TODO_GET_BATCH = 'todo/GET/BATCH';
 
 export const TODO_ADD = 'todo/ADD';
 export const TODO_ADD_BATCH = 'todo/ADD/BATCH';
 
 export const TODO_UPDATE = 'todo/UPDATE';
-export const TODO_UPDATE_ASYNC = 'todo/UPDATE_ASYNC';
+export const TODO_UPDATE_BATCH = 'todo/UPDATE/BATCH';
 
 export const TODO_DELETE = 'todo/DELETE';
-export const TODO_DELETE_ASYNC = 'todo/DELETE_ASYNC';
+export const TODO_DELETE_BATCH = 'todo/DELETE/BATCH';
+
+export const TODO_SYNC = 'todo/SYNC';
 
 export const LABEL_SET = 'label/SET';
 export const LABEL_GET = 'label/GET';
 
-export const TODO_FAIL = 'todo/GET/FAIL';
-
 // action
 export const getTodo = createAction(TODO_GET);
-export const successRequestTodo = createAction(
-  TODO_SET,
-  ({ edges }: Github_Edges<Github_Issue>) => {
-    const todoList: Array<Todo> = edges.map(
-      ({ node }: Github_Node<Github_Issue>) => {
-        const labelList =
-          node?.labels?.edges?.map(
-            ({ node }: Github_Node<Label>): Label => ({ ...node }),
-          ) ?? [];
-
-        return {
-          title: node.title,
-          body: node.bodyHTML,
-          id: node.id,
-          status: STATUS_NORMAL,
-          labelList,
-        };
-      },
-    );
-
-    return todoList;
-  },
-);
-
 export const addTodo = createAction(
   TODO_ADD,
-  ({ title, body, labelList = [] }: Todo) => {
+  ({
+    title,
+    body,
+    labels = [],
+    updatedAt = new Date().toISOString(),
+  }: Todo) => {
     return {
+      updatedAt,
       id: createUniqueId(),
       title,
       body,
-      labelList,
+      labels,
       status: STATUS_CREATE,
     };
   },
 );
 
 export const updateTodo = createAction(
-  TODO_UPDATE_ASYNC,
-  ({ id, title, body }: Todo) => ({
+  TODO_UPDATE,
+  ({
     id,
     title,
     body,
+    labels = [],
+    updatedAt = new Date().toISOString(),
+  }: Todo) => ({
+    updatedAt,
+    id,
+    title,
+    body,
+    labels,
+    status: STATUS_UPDATE,
   }),
 );
 
-export const deleteTodo = createAction(TODO_DELETE_ASYNC, (id: TODO_ID) => ({
+export const deleteTodo = createAction(TODO_DELETE, (id: TODO_ID) => ({
   id,
+  status: STATUS_DELETE,
 }));
+
 export const getLabel = createAction(LABEL_GET);
 
 // initialState
@@ -111,7 +97,7 @@ const initialTodoListState: TODO_LIST = getItem(
 );
 
 const initialLabelListState: LABEL_LIST = getItem(
-  TODO_KEY,
+  LABEL_KEY,
   defaultLabelList,
   false,
 );

--- a/src/redux/todo.ts
+++ b/src/redux/todo.ts
@@ -1,13 +1,7 @@
-import { Observable, of } from 'rxjs';
 import { createAction, handleActions, Action } from 'redux-actions';
-import { Epic, ofType, combineEpics, StateObservable } from 'redux-observable';
-import { mergeMap, map, catchError, delay } from 'rxjs/operators';
-import { AjaxResponse } from 'rxjs/ajax';
 
-import { ActionInterface } from '@/redux';
-import { request } from '@/redux/common';
 import { setItem, getItem } from '@/utils/localStorage';
-import { getLabelQuery } from '@/githubApi/label';
+import { createUniqueId } from '@/utils/common';
 import {
   TODO_LIST,
   LABEL_LIST,
@@ -16,20 +10,19 @@ import {
   Github_Issue,
   Github_Node,
   Github_Edges,
+  TODO_ID,
 } from '@/model';
-import {
-  getIssueQuery,
-  createIssueQuery,
-  updateIssueQuery,
-  deleteIssueQuery,
-} from '@/githubApi/issue';
-import { createUniqueId } from '@/utils/common';
 
 // payload interface
 export interface ITodoState {
   todoItems: TODO_LIST;
   label: LABEL_LIST;
 }
+
+const STATUS_CREATE = 'created';
+const STATUS_MODIFY = 'modify';
+const STATUS_DELETE = 'delete';
+const STATUS_NORMAL = 'normal';
 
 // type
 export const BATCH = 'todo/BATCH';
@@ -40,8 +33,6 @@ export const TODO_ITEM_SET = 'todo/ITEM/SET';
 
 export const TODO_ADD = 'todo/ADD';
 export const TODO_ADD_BATCH = 'todo/ADD/BATCH';
-
-export const TODO_DONE = 'todo/DONE';
 
 export const TODO_UPDATE = 'todo/UPDATE';
 export const TODO_UPDATE_ASYNC = 'todo/UPDATE_ASYNC';
@@ -70,7 +61,7 @@ export const successRequestTodo = createAction(
           title: node.title,
           body: node.bodyHTML,
           id: node.id,
-          status: 'normal',
+          status: STATUS_NORMAL,
           labelList,
         };
       },
@@ -88,7 +79,7 @@ export const addTodo = createAction(
       title,
       body,
       labelList,
-      status: 'created',
+      status: STATUS_CREATE,
     };
   },
 );
@@ -102,152 +93,10 @@ export const updateTodo = createAction(
   }),
 );
 
-export const deleteTodo = createAction(TODO_DELETE_ASYNC, (id: string) => {
-  return { id };
-});
-
+export const deleteTodo = createAction(TODO_DELETE_ASYNC, (id: TODO_ID) => ({
+  id,
+}));
 export const getLabel = createAction(LABEL_GET);
-
-// epic
-const getTodoEpic: Epic<ActionInterface> = (
-  action$: Observable<ActionInterface>,
-  state$: StateObservable<any>,
-) => {
-  return action$.pipe(
-    ofType<ActionInterface>(TODO_GET),
-    mergeMap(() => {
-      return request(getIssueQuery(state$.value.auth)).pipe(
-        map(({ response: { data } }: AjaxResponse) =>
-          successRequestTodo(data.repository.issues),
-        ),
-      );
-    }),
-  );
-};
-
-const addTodoEpic: Epic<ActionInterface> = (
-  action$: Observable<ActionInterface>,
-  state$: StateObservable<any>,
-) => {
-  return action$.pipe(
-    ofType<ActionInterface>(TODO_ADD, TODO_ADD_BATCH),
-    mergeMap(({ payload }: ActionInterface) => {
-      const respositoryID = state$.value?.auth.repoID;
-      return request(createIssueQuery(respositoryID, payload)).pipe(
-        map(({ response: { data } }: AjaxResponse) => {
-          of({ type: TODO_ITEM_SET }, { type: TODO_SET });
-          return {
-            type: TODO_ITEM_SET,
-            payload: {
-              targetId: payload.id,
-              todoItem: {
-                id: data.createIssue.issue.id,
-                title: payload.title,
-                body: payload.body,
-                labelList: payload.labelList,
-                status: 'normal',
-              },
-            },
-          };
-        }),
-        catchError(() =>
-          of({
-            type: BATCH,
-            payload: {
-              type: TODO_ADD,
-              payload,
-            },
-            error: true,
-          }),
-        ),
-      );
-    }),
-  );
-};
-
-const updateTodoEpic: Epic<ActionInterface> = (
-  action$: Observable<ActionInterface>,
-  state$: StateObservable<any>,
-) => {
-  return action$.pipe(
-    ofType<ActionInterface>(TODO_UPDATE_ASYNC),
-    mergeMap((action: ActionInterface) =>
-      request(updateIssueQuery(action.payload)).pipe(
-        map(({ response: { data } }: AjaxResponse) => ({
-          type: TODO_UPDATE,
-          payload: {
-            ...data.updateIssue.issue,
-          },
-        })),
-      ),
-    ),
-  );
-};
-
-const deleteTodoEpic: Epic<ActionInterface> = (
-  action$: Observable<ActionInterface>,
-  state$: StateObservable<any>,
-) => {
-  return action$.pipe(
-    ofType<ActionInterface>(TODO_DELETE_ASYNC),
-    mergeMap((action: ActionInterface) => {
-      const issueID = action.payload && action.payload.id;
-      return request(deleteIssueQuery(issueID)).pipe(
-        map(({ response: { data } }: AjaxResponse) => ({
-          type: TODO_DELETE,
-          payload: {
-            ...action.payload,
-            id: data.closeIssue.issue.id,
-          },
-        })),
-      );
-    }),
-  );
-};
-
-// TODO feature: 투두 추가|수정|삭제 이후 서버의 데이터와 일치하는지 확인하는 기능
-
-const getLabelEpic: Epic<ActionInterface> = (
-  action$: Observable<ActionInterface>,
-  state$: StateObservable<any>,
-) => {
-  return action$.pipe(
-    ofType<ActionInterface>(LABEL_GET),
-    mergeMap(() =>
-      request(getLabelQuery(state$.value.auth)).pipe(
-        map(({ response: { data } }: AjaxResponse) => {
-          const labelList: LABEL_LIST = data.repository.labels.edges.map(
-            ({ node }: Github_Node<Label>) => ({
-              id: node.id,
-              name: node.name,
-              color: node.color,
-            }),
-          );
-
-          return {
-            type: LABEL_SET,
-            payload: labelList,
-          };
-        }),
-      ),
-    ),
-  );
-};
-
-const batchEpic: Epic<ActionInterface> = (
-  action$: Observable<ActionInterface>,
-) => {
-  return action$.pipe(
-    ofType<ActionInterface>(BATCH),
-    delay(4000),
-    map(({ payload }: ActionInterface) => {
-      return {
-        ...payload,
-        type: payload.type + '/BATCH',
-      };
-    }),
-  );
-};
 
 // initialState
 const TODO_KEY = 'todo';
@@ -292,7 +141,7 @@ export const todoReducer = handleActions<ITodoState, any>(
     ): ITodoState => {
       const todoItems = state.todoItems.map(item =>
         item.id === payload.targetId
-          ? { ...payload.todoItem, status: 'normal' }
+          ? { ...payload.todoItem, status: STATUS_NORMAL }
           : item,
       );
       setItem(TODO_KEY, todoItems, false);
@@ -351,13 +200,4 @@ export const todoReducer = handleActions<ITodoState, any>(
     },
   },
   initialState,
-);
-
-export const todoEpic = combineEpics(
-  getTodoEpic,
-  getLabelEpic,
-  addTodoEpic,
-  updateTodoEpic,
-  deleteTodoEpic,
-  batchEpic,
 );

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,23 @@
-import { Github_Edges, Label, LABEL_LIST } from '@/model';
+import {
+  Github_Edges,
+  Github_Node,
+  Github_Issue,
+  TODO_LIST,
+  Label,
+  LABEL_LIST,
+} from '@/model';
+import { STATUS_NORMAL } from '@/redux/todo';
+
+export const getIssues = (issues: Github_Edges<Github_Issue>): TODO_LIST => {
+  return issues.edges.map(({ node }: Github_Node<Github_Issue>) => ({
+    updatedAt: node.updatedAt,
+    title: node.title,
+    body: node.bodyHTML,
+    id: node.id,
+    status: STATUS_NORMAL,
+    labelList: getLabels(node.labels),
+  }));
+};
 
 export const getLabels = (labels: Github_Edges<Label>): LABEL_LIST => {
   return labels.edges.map(({ node }) => ({

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,3 +5,12 @@ export const getLabels = (labels: Github_Edges<Label>): LABEL_LIST => {
     ...node,
   }));
 };
+
+export const createUniqueId = () => {
+  return (
+    '_' +
+    Math.random()
+      .toString(36)
+      .substr(2, 9)
+  );
+};

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,7 @@
+import { Github_Edges, Label, LABEL_LIST } from '@/model';
+
+export const getLabels = (labels: Github_Edges<Label>): LABEL_LIST => {
+  return labels.edges.map(({ node }) => ({
+    ...node,
+  }));
+};


### PR DESCRIPTION
# Description

## Epic 설계

기존에 제대로 잡혀있지 않던 Epic에 대해서 정의를 진행했습니다. 관련 이미지 2개를 아래에 추가하였습니다.

![Epic-Work-Flow](https://user-images.githubusercontent.com/24274424/78846293-4446a000-7a46-11ea-9161-a8bdff676428.png)

각각의 Epic에 대한 Work-Flow로 Epic이 어떤 처리를 해야하며 다음으로는 어떤 Action을 실행해야하는지 명세를 하였습니다.

![Epic-Flow](https://user-images.githubusercontent.com/24274424/78846298-4577cd00-7a46-11ea-9798-a5a7e944cc5b.png)

Action이 Dispatch되는 과정을 Ecpic관점에서 Marble Diagram을 그려보았습니다. 위의 사진은 일반적인 Network가 연결되어있는 상태와 연결되어있지 않은 상태를 나타냅니다.

## 폴더 구조 변경

Duck Pattern으로 하여 구현을 하고 있었으나 Epic의 기능이 많이 들어가게되면서 가독성이 더 떨어지는 현상이 발생하여 Epic 부분만 별도의 폴더로 빼는 작업을 진행하였습니다.

## Model 변경

- [x] Todo의 updatedAt을 추가하였습니다. Github API에 따라 ISO string을 기준으로 추가하였습니다.
- [x] modified을 제거하고 status라는 todo의 상태값을 추가하였습니다. 이는 api요청이 이루어지고 결과가 나오기 전의 todo에 중요한 상태값으로 Network가 없을 경우 이후에 처리할 대상이 됩니다.
- [x] labelList => labels Github API의 키값과 동일하게 변경하였습니다.

## Query 수정

- [x] updatedAt이 추가되었습니다.
- [x] createIssueQuery return값이 추가 되었습니다.

## Epic 추가

- [x] Network 에러시 주기적으로 다시 요청해주는 batchEpic이 추가되었습니다.
- [ ] Update, Delete 성공시 동기화를 진행할 syncEpic 영역을 추가하였습니다. (미구현)
    - Create관련하여 Sync를 진행할지는 논의대상

