### PR TITLE
[feature/config-page] Config Page 화면 구성 및 기능 추가

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -2,15 +2,11 @@ import Main from '@/components/Main';
 import Config from '@/components/Config';
 import { Store } from 'redux';
 
-const PATH_INDEX: string = 'index';
-const PATH_CONFIG: string = 'config';
-
 class App {
   $target: HTMLElement;
   $main: Main | null = null;
   $config: Config | null = null;
   rootStore: any;
-  currentPath: string = PATH_CONFIG;
 
   constructor($target: HTMLElement, store: Store) {
     this.$target = $target;
@@ -21,14 +17,31 @@ class App {
         data: this.rootStore.auth,
         dispatch: store.dispatch,
       });
-      this.currentPath = PATH_CONFIG;
     } else {
       this.$main = new Main($target, {
         data: this.rootStore.todo,
         dispatch: store.dispatch,
       });
-      this.currentPath = PATH_INDEX;
     }
+
+    // store의 변경사항 감지 및 리렌더링
+    store.subscribe(() => {
+      const nextRootStore = store.getState();
+
+      if (this.rootStore.auth.repoID === '') {
+        this.$target.innerHTML = '';
+        this.$main = new Main(this.$target, {
+          data: nextRootStore.todo,
+          dispatch: store.dispatch,
+        });
+      } else {
+        this.$target.innerHTML = '';
+        this.$config = new Config($target, {
+          data: nextRootStore.auth,
+          dispatch: store.dispatch,
+        });
+      }
+    });
   }
 }
 

--- a/src/components/Config.ts
+++ b/src/components/Config.ts
@@ -1,3 +1,5 @@
+import { userLogin } from '@/redux/auth';
+
 class Config {
   $configPage: HTMLElement;
   data: any; // Todo 정의 필요
@@ -26,7 +28,7 @@ class Config {
       <section class="config__top">
         <div class="config__top__owner-container">
           <label for="config__owner-input">Owner</label>
-          <input type="text" id="config__owner-input">
+          <input type="text" id="config__owner-input" autofocus>
         </div>
         <div class="config__top__repo-container">
           <label for="config__repo-input">Repo Name</label>
@@ -37,10 +39,31 @@ class Config {
           <input type="text" id="config__token-input">
         </div>
       </section>
+
       <section class="config__bottom">
         <button class="config__bottom__check-btn">Check</button>
       </section>
     `;
+
+    const checkBtn = document.getElementsByClassName(
+      'config__bottom__check-btn',
+    )[0];
+
+    checkBtn.addEventListener('click', () => {
+      const owner = (<HTMLInputElement>(
+        document.getElementById('config__owner-input')
+      )).value;
+      const repoName = (<HTMLInputElement>(
+        document.getElementById('config__repo-input')
+      )).value;
+      const token = (<HTMLInputElement>(
+        document.getElementById('config__token-input')
+      )).value;
+
+      if (owner && repoName && token) {
+        this.dispatch(userLogin({ owner, repoName, token }));
+      }
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import configureStore from '@/redux';
 import App from '@/components/App';
 
+import './reset.css';
+import './style.css';
+
 const store = configureStore();
 
 new App(document.getElementById('app') || document.body, store);

--- a/src/reset.css
+++ b/src/reset.css
@@ -1,0 +1,129 @@
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,51 @@
+body {
+  width: 300px;
+  height: 400px;
+
+  font-size: 16px;
+}
+
+label {
+  display: block;
+  margin: 15px 0px 5px;
+}
+
+input[type="text"] {
+  border: 1px solid black;
+}
+
+#app {
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.config {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.config__top {
+  margin-bottom: 30px;
+}
+
+.config__top input {
+  width: 160px;
+  height: 25px;
+}
+
+.config__bottom__check-btn {
+  width: 80px;
+  height: 30px;
+
+  background-color: transparent;
+  border: 1px solid black;
+  border-radius: 15px;
+
+  cursor: pointer;
+}


### PR DESCRIPTION
# Description

## Config 화면 구성

![image](https://user-images.githubusercontent.com/24274424/79766608-2987fb80-8363-11ea-915c-909b5d932e6d.png)

- body size : 300 x 400
- owner, repo name, token 입력창 추가
- login 버튼 추가 및 기능 추가
- login 성공시 main 페이지로 이동하도록 추가
- reset.css 추가

### Issue

- [ ] 로그인 실패시 에러처리가 되어있지 않음
- [ ] Login 진행중 일경우 Loading 바와 같은 UX가 존재하지 않음